### PR TITLE
Allow upgrading packages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,9 @@
 #
 # @param asinstall
 # @param version
+#   aerospike version
+# @param package_ensure
+#  e.g. `installed|latest`, default: latest
 # @param download_dir
 # @param download_url
 # @param remove_archive
@@ -58,6 +61,7 @@
 class aerospike (
   Boolean              $asinstall                = true,
   String               $version                  = '5.7.0.11',
+  Optional[String]     $package_ensure           = undef,
   Stdlib::Absolutepath $download_dir             = '/usr/local/src',
   Optional[String]     $download_url             = undef,
   Boolean              $remove_archive           = false,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -45,7 +45,7 @@ class aerospike::install {
         extract  => false,
         cleanup  => $aerospike::remove_archive,
       } ~> package { "aerospike-server-${aerospike::edition}":
-        ensure   => installed,
+        ensure   => latest,
         provider => 'dpkg',
         source   => "${dest}.deb",
       }
@@ -59,7 +59,7 @@ class aerospike::install {
         extract  => false,
         cleanup  => $aerospike::remove_archive,
       } ~> package { "aerospike-server-${aerospike::edition}":
-        ensure   => installed,
+        ensure   => latest,
         provider => 'rpm',
         source   => "${dest}.rpm",
       }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -95,7 +95,7 @@ class aerospike::install {
       ensure  => present,
       uid     => $aerospike::system_uid,
       gid     => $aerospike::system_group,
-      shell   => '/bin/bash',
+      shell   => '/usr/sbin/nologin',
       require => Group[$aerospike::system_group],
     }
   )

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,6 +11,11 @@
 class aerospike::install {
   include archive
 
+  $_package_version = $aerospike::package_ensure ? {
+    undef   => latest,
+    default => $aerospike::package_ensure
+  }
+
   # #######################################
   # Installation of aerospike server
   # #######################################
@@ -45,7 +50,7 @@ class aerospike::install {
         extract  => false,
         cleanup  => $aerospike::remove_archive,
       } ~> package { "aerospike-server-${aerospike::edition}":
-        ensure   => latest,
+        ensure   => $_package_version,
         provider => 'dpkg',
         source   => "${dest}.deb",
       }
@@ -59,7 +64,7 @@ class aerospike::install {
         extract  => false,
         cleanup  => $aerospike::remove_archive,
       } ~> package { "aerospike-server-${aerospike::edition}":
-        ensure   => latest,
+        ensure   => $_package_version,
         provider => 'rpm',
         source   => "${dest}.rpm",
       }

--- a/spec/classes/aerospike_spec.rb
+++ b/spec/classes/aerospike_spec.rb
@@ -365,7 +365,7 @@ describe 'aerospike' do
 
     it {
       is_expected.to contain_package('aerospike-server-community')\
-        .with_ensure(%r{installed|present})\
+        .with_ensure(%r{latest})\
         .with_source('/usr/local/src/aerospike-server-community-5.7.0.16-debian10.deb')
     }
   end
@@ -404,7 +404,7 @@ describe 'aerospike' do
 
     it {
       is_expected.to contain_package('aerospike-server-community')\
-        .with_ensure(%r{installed|present})\
+        .with_ensure(%r{latest})\
         .with_source('/usr/local/src/aerospike-server-community-5.7.0.16-el8.rpm')
     }
   end

--- a/spec/classes/aerospike_spec.rb
+++ b/spec/classes/aerospike_spec.rb
@@ -216,7 +216,7 @@ describe 'aerospike' do
           .with_ensure('present')\
           .with_uid(511)\
           .with_gid('as_group')\
-          .with_shell('/bin/bash')
+          .with_shell('/usr/sbin/nologin')
       end
 
       it do


### PR DESCRIPTION
Ensure `present` won't trigger any change upon version upgrade. Note even though package is upgraded service isn't currently restarted.